### PR TITLE
Paylocity paycheck parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,27 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [1.4.0] - 2025-08-10
+
+PR: [#8](https://github.com/jozecuervo/ofw-tools/pull/8)
+
+### Added
+- Paylocity paychecks → CSV CLI (`paylocity.js`) and parser (`utils/paylocity/parser.js`): scan a folder of Paylocity paycheck PDFs and produce a single CSV (one row per paycheck).
+- `--debug-text` flag: writes normalized PDF text to `<source>/_debug_text/` for troubleshooting.
+
+### Changed
+- Parser robustness: handles month-name dates (e.g., "August 1, 2025"), numeric dates anywhere in line, "Period Beginning/Ending" labels, negative/parentheses amounts, compact tax-line formats (FIT/SS/MED), and line-wrapped labels.
+- README updated with usage and options for the new tool.
+
+### Scripts
+- `npm run paylocity` wired to `node paylocity.js`.
+
+### Tests
+- Existing suites remain green (no regressions).
+
 ## [1.3.0] - 2025-08-10
+
+PR: [#7](https://github.com/jozecuervo/ofw-tools/pull/7)
 
 ### Added
 - Utilities split for maintainability and testing:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,24 @@
 
 ### Overview
 
-This repository contains a set of small, focused tools that help analyze communications, plan visitation schedules, and perform basic family-law-related calculations (Moore/Marsden, apportionment). These are optimized for quick, local use as you prepare materials for court.
+Local-first Node.js CLIs that streamline common family-law workflows. These tools help you quickly analyze communications, generate calendars, compute property/equity figures, and now parse paychecks — all on your machine for privacy and speed. Outputs favor simple formats (CSV/Markdown/JSON) that drop easily into exhibits or spreadsheets.
+
+What’s included:
+- Messages and evidence prep
+  - OFW Messages PDF → JSON/CSV summaries with weekly stats and console Markdown
+  - iMessage text export → per-year JSON with sentiment metrics
+- Scheduling and analysis
+  - Visitation calendar helper with court-style week logic and annotated grids
+  - Fifth-week analyzer to quantify months with “5th” occurrences of anchor weekdays
+- Property and finance calculators
+  - Moore/Marsden worksheet and apportionment/buyout with credits (Watts/Epstein/fees)
+- Payroll parsing
+  - Paylocity paycheck PDFs → single CSV (one row per paycheck) with robust field extraction
+
+Design principles:
+- Fast, private, and offline by default (no external services)
+- Vanilla JavaScript, clear CLIs, and predictable file outputs
+- Small, testable modules with focused responsibility
 
 ### Quick Start
 
@@ -25,6 +42,7 @@ Pass arguments after `--`.
 - Moore/Marsden calculation (example values): `npm run moore-marsden`
 - Apportionment & buyout calculator (example values): `npm run apportionment`
 - iMessage parser with sentiment: `npm run imessage -- /absolute/path/to/imessage.txt`
+- Paylocity paychecks → CSV: `npm run paylocity -- /absolute/path/to/folder/of/pdfs`
 
 ---
 
@@ -146,6 +164,20 @@ Pass arguments after `--`.
   npm run apportionment -- --config ./source_files/apportionment.config.json --out-json ./output/apportionment.json
   ```
  - **Notes**: Neutral, even-number example defaults to illustrate formulas. Future enhancement: toggles for Epstein-only vs. equity allocation and FRV offsets.
+
+### 8) Paylocity Paychecks → CSV (`paylocity.js`)
+
+- **Purpose**: Scan a folder of Paylocity paycheck PDFs and produce a single CSV with one row per paycheck.
+- **Input**: Path to a folder containing `.pdf` paystubs exported from Paylocity.
+- **Output**: `same-folder/paychecks.csv` by default; override with `--out <file.csv>`.
+- **Run**:
+  ```bash
+  npm run paylocity -- /absolute/path/to/paystubs
+  npm run paylocity -- /absolute/path/to/paystubs -- --out /absolute/path/to/output/paychecks.csv
+  npm run paylocity -- /absolute/path/to/paystubs -- --glob 2025   # only files with '2025' in name
+  ```
+- **Columns**: `File, Pay Date, Period Start, Period End, Gross Pay, Net Pay, Total Taxes, Total Deductions, Federal Income Tax, State Income Tax, Social Security, Medicare`.
+- **Notes**: Parser is resilient to minor label shifts (e.g., "Pay Date" vs. "Check Date"; "Pay Period" range or separate Begin/End). Missing values are left blank.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ofw-tools",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "This repository contains a set of small, focused tools that help analyze communications, plan visitation schedules, and perform basic family-law-related calculations (Moore/Marsden, apportionment). These are optimized for quick, local use as you prepare materials for court.",
   "main": "index.js",
   "scripts": {
@@ -15,7 +15,8 @@
     "apportionment": "node apportionment-calc.js",
     "imessage": "node imessage.js",
     "imessage:install": "brew install imessage-exporter",
-    "imessage:export": "imessage-exporter --export-type plain-text --output-dir ./output"
+    "imessage:export": "imessage-exporter --export-type plain-text --output-dir ./output",
+    "paylocity": "node paylocity.js"
   },
   "author": "",
   "license": "CC0-1.0",

--- a/paylocity.js
+++ b/paylocity.js
@@ -1,0 +1,162 @@
+"use strict";
+
+/**
+ * Paylocity Paycheck Folder → CSV
+ *
+ * Usage:
+ *   node paylocity.js <source-folder> [--out <file.csv>]
+ *
+ * Scans the folder for .pdf files, parses each with pdf-parse, extracts key fields,
+ * and writes a single CSV with one row per paycheck.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const { parsePdf } = require("./utils");
+const { writeFile, ensureDir } = require("./utils");
+const { parsePaylocityPaystub, normalizeText } = require("./utils/paylocity/parser");
+
+function printHelp() {
+  console.log(`\nUsage: node paylocity.js <source-folder> [--out <file.csv>] [--glob <pattern>]\n\nOptions:\n  --out <file.csv>   Destination CSV path. Default: <source-folder>/paychecks.csv\n  --glob <pattern>   Only include PDFs whose filename contains this substring (case-insensitive)\n  -h, --help         Show this help\n`);
+}
+
+function listPdfFilesInDir(dirPath) {
+  const entries = fs.readdirSync(dirPath, { withFileTypes: true });
+  return entries
+    .filter((e) => e.isFile())
+    .map((e) => path.join(dirPath, e.name))
+    .filter((p) => p.toLowerCase().endsWith(".pdf"))
+    .sort();
+}
+
+function toCsvValue(value) {
+  if (value == null) return "";
+  const str = String(value);
+  if (/[",\n]/.test(str)) {
+    return '"' + str.replace(/"/g, '""') + '"';
+  }
+  return str;
+}
+
+function buildHeaderRow() {
+  return [
+    "File",
+    "Pay Date",
+    "Period Start",
+    "Period End",
+    "Gross Pay",
+    "Net Pay",
+    "Total Taxes",
+    "Total Deductions",
+    "Federal Income Tax",
+    "State Income Tax",
+    "Social Security",
+    "Medicare",
+  ].join(",");
+}
+
+function recordToRow(filePath, record) {
+  return [
+    path.basename(filePath),
+    record.payDate,
+    record.periodStart,
+    record.periodEnd,
+    record.grossPay,
+    record.netPay,
+    record.totalTaxes,
+    record.totalDeductions,
+    record.federalIncomeTax,
+    record.stateIncomeTax,
+    record.socialSecurity,
+    record.medicare,
+  ]
+    .map(toCsvValue)
+    .join(",");
+}
+
+async function parseOnePdf(filePath, debugDir) {
+  const rawText = await parsePdf(filePath);
+  if (debugDir) {
+    const base = path.basename(filePath, path.extname(filePath));
+    const out = path.join(debugDir, `${base}.txt`);
+    writeFile(out, normalizeText(rawText));
+  }
+  return parsePaylocityPaystub(rawText);
+}
+
+async function main() {
+  const rawArgs = process.argv.slice(2);
+  if (rawArgs.includes("-h") || rawArgs.includes("--help")) {
+    printHelp();
+    process.exit(0);
+  }
+  if (rawArgs.length === 0) {
+    printHelp();
+    process.exit(1);
+  }
+
+  const sourceDir = path.resolve(rawArgs[0]);
+  if (!fs.existsSync(sourceDir) || !fs.statSync(sourceDir).isDirectory()) {
+    console.error(`Source folder not found or not a directory: ${sourceDir}`);
+    process.exit(1);
+  }
+
+  let outCsv = null;
+  const outIdx = rawArgs.indexOf("--out");
+  if (outIdx !== -1) {
+    const val = rawArgs[outIdx + 1];
+    if (val && !val.startsWith("--")) outCsv = path.resolve(val);
+  }
+  if (!outCsv) {
+    outCsv = path.join(sourceDir, "paychecks.csv");
+  }
+
+  let nameFilter = null;
+  const globIdx = rawArgs.indexOf("--glob");
+  if (globIdx !== -1) {
+    const val = rawArgs[globIdx + 1];
+    if (val && !val.startsWith("--")) nameFilter = val.toLowerCase();
+  }
+
+  const pdfFiles = listPdfFilesInDir(sourceDir).filter((p) =>
+    nameFilter ? path.basename(p).toLowerCase().includes(nameFilter) : true
+  );
+  if (pdfFiles.length === 0) {
+    console.error("No PDF files found in source folder.");
+    process.exit(1);
+  }
+
+  const header = buildHeaderRow();
+  const rows = [header];
+
+  // Optional debug text dump
+  const debugDir = rawArgs.includes("--debug-text") ? path.join(sourceDir, "_debug_text") : null;
+  if (debugDir) ensureDir(debugDir);
+
+  for (const filePath of pdfFiles) {
+    try {
+      const record = await parseOnePdf(filePath, debugDir);
+      rows.push(recordToRow(filePath, record));
+      console.log(`Parsed: ${path.basename(filePath)}`);
+    } catch (err) {
+      console.error(`Failed to parse ${filePath}:`, err.message || err);
+    }
+  }
+
+  const csv = rows.join("\n") + "\n";
+  ensureDir(path.dirname(outCsv));
+  writeFile(outCsv, csv);
+  console.log(`\nWrote ${pdfFiles.length} row(s) to ${outCsv}`);
+  if (debugDir) console.log(`Normalized text dumps written to ${debugDir}`);
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error("Unhandled error:", err);
+    process.exit(1);
+  });
+}
+
+module.exports = { main };
+
+

--- a/utils/paylocity/parser.js
+++ b/utils/paylocity/parser.js
@@ -1,0 +1,282 @@
+"use strict";
+
+/**
+ * Paylocity Paycheck PDF text parser
+ *
+ * Extracts key fields from Paylocity paystub text. Written to be tolerant of layout changes:
+ * - Supports labels like "Pay Date" or "Check Date"
+ * - Supports "Pay Period: MM/DD/YYYY - MM/DD/YYYY" and separate Begin/End labels
+ * - Searches common summary labels for Gross, Net, Taxes, and Deductions
+ *
+ * Returns string dates as MM/DD/YYYY and numeric amounts as Numbers (or null if missing).
+ */
+
+/**
+ * Parse a US currency string into a Number.
+ * Accepts optional leading $ and thousands separators.
+ */
+function parseMoneyStringToNumber(value) {
+  if (value == null) return null;
+  const raw = String(value).trim();
+  const isNegative = /\(\s*[^)]+\s*\)/.test(raw) || /^-/.test(raw);
+  const cleaned = raw.replace(/[()$,\s]/g, "").replace(/^[-]/, "");
+  if (cleaned === "") return null;
+  const num = Number(cleaned);
+  if (!Number.isFinite(num)) return null;
+  return isNegative ? -num : num;
+}
+
+/**
+ * Get first capturing group for a list of patterns.
+ */
+function firstMatch(text, regexes) {
+  for (const rx of regexes) {
+    const m = rx.exec(text);
+    if (m && m[1]) return m[1];
+  }
+  return null;
+}
+
+/**
+ * Get first pair (two capturing groups) for a list of patterns.
+ */
+function firstMatchPair(text, regexes) {
+  for (const rx of regexes) {
+    const m = rx.exec(text);
+    if (m && m[1]) return { a: m[1], b: m[2] };
+  }
+  return { a: null, b: null };
+}
+
+/**
+ * Normalize PDF text for robust regexes: collapse repeated spaces, keep newlines, unify dashes.
+ */
+function normalizeText(input) {
+  return String(input)
+    .replace(/[\u2013\u2014]/g, "-") // en/em dash → hyphen
+    .replace(/\u00A0/g, " ") // nbsp → space
+    .replace(/[ \t]+/g, " ") // collapse spaces (not newlines)
+    .trim();
+}
+
+function monthNameToNumber(name) {
+  const map = {
+    january: 1, february: 2, march: 3, april: 4, may: 5, june: 6,
+    july: 7, august: 8, september: 9, october: 10, november: 11, december: 12,
+  };
+  const n = map[String(name || '').toLowerCase()];
+  return n || null;
+}
+
+function formatMMDDYYYY(month, day, year) {
+  const mm = String(month).padStart(2, '0');
+  const dd = String(day).padStart(2, '0');
+  return `${mm}/${dd}/${year}`;
+}
+
+function normalizeDateString(dateStr) {
+  if (!dateStr) return null;
+  // Find date tokens anywhere in the string
+  const nameAnywhere = dateStr.match(/([A-Za-z]+\s+\d{1,2},\s*\d{4})/);
+  if (nameAnywhere && nameAnywhere[1]) {
+    const parts = nameAnywhere[1].match(/^([A-Za-z]+)\s+(\d{1,2}),\s*(\d{4})$/);
+    if (parts) {
+      const m = monthNameToNumber(parts[1]);
+      if (m) return formatMMDDYYYY(m, Number(parts[2]), parts[3]);
+    }
+  }
+  const mdYAnywhere = dateStr.match(/(\d{1,2})[\/-](\d{1,2})[\/-](\d{4})/);
+  if (mdYAnywhere && mdYAnywhere[1]) {
+    return formatMMDDYYYY(Number(mdYAnywhere[1]), Number(mdYAnywhere[2]), mdYAnywhere[3]);
+  }
+  // Fallback: strict matches (unlikely reached now)
+  const mdY = dateStr.match(/^(\d{1,2})[\/-](\d{1,2})[\/-](\d{4})$/);
+  if (mdY) return formatMMDDYYYY(Number(mdY[1]), Number(mdY[2]), mdY[3]);
+  const name = dateStr.match(/^([A-Za-z]+)\s+(\d{1,2}),\s*(\d{4})$/);
+  if (name) {
+    const m = monthNameToNumber(name[1]);
+    if (m) return formatMMDDYYYY(m, Number(name[2]), name[3]);
+  }
+  return null;
+}
+
+function findDateAfterLabel(text, label) {
+  const lower = text.toLowerCase();
+  const idx = lower.indexOf(label.toLowerCase());
+  if (idx === -1) return null;
+  const slice = text.slice(idx + label.length, idx + label.length + 80);
+  const nameMatch = slice.match(/([A-Za-z]+\s+\d{1,2},\s*\d{4})/);
+  if (nameMatch && nameMatch[1]) return nameMatch[1];
+  const numMatch = slice.match(/(\d{1,2}[\/-]\d{1,2}[\/-]\d{4})/);
+  if (numMatch && numMatch[1]) return numMatch[1];
+  return null;
+}
+
+/**
+ * Extract a dollar amount by label, allowing for either order and line breaks.
+ * Tries these layouts:
+ *  - "Label: $1,234.56"
+ *  - "Label" followed by amount on next token/line
+ *  - "$1,234.56 Label"
+ */
+function extractAmountByLabel(text, labels) {
+  const amountPattern = "\\(?-?\\$?([0-9]{1,3}(?:,[0-9]{3})*(?:\\.[0-9]{2})|[0-9]+(?:\\.[0-9]{2}))\\)?";
+  const joinedLabels = labels.map(l => l.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&")).join("|");
+
+  const regexes = [
+    // Label: $1,234.56  (same line)
+    new RegExp(`(?:${joinedLabels})\s*[:]?\s*${amountPattern}`, "i"),
+    // Label\n$1,234.56  (next line)
+    new RegExp(`(?:${joinedLabels})\s*[:]?\s*[\n\r]+\s*${amountPattern}`, "i"),
+    // $1,234.56 Label  (amount first)
+    new RegExp(`${amountPattern}\s*(?:${joinedLabels})`, "i"),
+  ];
+
+  for (const rx of regexes) {
+    const m = rx.exec(text);
+    if (m && m[1]) return parseMoneyStringToNumber(m[1]);
+  }
+  return null;
+}
+
+/**
+ * Parse Paylocity paystub text into a normalized paycheck record.
+ * @param {string} rawText
+ * @returns {{
+ *   payDate: string|null,
+ *   periodStart: string|null,
+ *   periodEnd: string|null,
+ *   grossPay: number|null,
+ *   netPay: number|null,
+ *   totalTaxes: number|null,
+ *   totalDeductions: number|null,
+ *   federalIncomeTax: number|null,
+ *   stateIncomeTax: number|null,
+ *   socialSecurity: number|null,
+ *   medicare: number|null,
+ * }}
+ */
+function parsePaylocityPaystub(rawText) {
+  const text = normalizeText(rawText);
+  const lines = text.split(/\r?\n/).map(l => l.trim()).filter(Boolean);
+
+  // Dates
+  let payDateRaw = firstMatch(text, [
+    /(?:Pay\s*Date|Check\s*Date)\s*:?\s*([0-1]?\d[\/-][0-3]?\d[\/-]\d{4})/i,
+    /(?:Pay\s*Date|Check\s*Date)\s*:?\s*([A-Za-z]+\s+\d{1,2},\s*\d{4})/i,
+  ]);
+  if (!payDateRaw) {
+    payDateRaw = findDateAfterLabel(text, 'Check Date') || findDateAfterLabel(text, 'Pay Date');
+  }
+  const payDate = normalizeDateString(payDateRaw);
+
+  let { a: periodStart, b: periodEnd } = firstMatchPair(text, [
+    /(?:Pay\s*Period)\s*:?\s*([0-1]?\d[\/-][0-3]?\d[\/-]\d{4})\s*-\s*([0-1]?\d[\/-][0-3]?\d[\/-]\d{4})/i,
+    /(?:Pay\s*Period)\s*:?\s*([A-Za-z]+\s+\d{1,2},\s*\d{4})\s*-\s*([A-Za-z]+\s+\d{1,2},\s*\d{4})/i,
+  ]);
+
+  if (!periodStart || !periodEnd) {
+    // Fallback: separate begin/end labels
+    const beginRaw = firstMatch(text, [/(?:Period\s*(?:Start|Begin|Beginning)\s*(?:Date)?)\s*:?\s*([0-1]?\d[\/-][0-3]?\d[\/-]\d{4})/i,
+                                      /(?:Period\s*(?:Start|Begin|Beginning)\s*(?:Date)?)\s*:?\s*([A-Za-z]+\s+\d{1,2},\s*\d{4})/i]);
+    const endRaw = firstMatch(text, [/(?:Period\s*(?:End|Ending)\s*(?:Date)?)\s*:?\s*([0-1]?\d[\/-][0-3]?\d[\/-]\d{4})/i,
+                                    /(?:Period\s*(?:End|Ending)\s*(?:Date)?)\s*:?\s*([A-Za-z]+\s+\d{1,2},\s*\d{4})/i]);
+    periodStart = normalizeDateString(beginRaw) || normalizeDateString(findDateAfterLabel(text, 'Period Beginning')) || normalizeDateString(findDateAfterLabel(text, 'Period Start'));
+    periodEnd = normalizeDateString(endRaw) || normalizeDateString(findDateAfterLabel(text, 'Period Ending')) || normalizeDateString(findDateAfterLabel(text, 'Period End'));
+  }
+
+  // Helper to scan lines for a label and pick the nearest currency on the same or next line
+  function extractFromLines(labelSynonyms, pick = 'first') {
+    const labelRegex = new RegExp(labelSynonyms.map(s => s.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&")).join("|"), "i");
+    const moneyRx = /\(?-?\$?[0-9]{1,3}(?:,[0-9]{3})*(?:\.[0-9]{2})\)?|\(?-?[0-9]+(?:\.[0-9]{2})\)?/g;
+    for (let i = 0; i < lines.length; i++) {
+      if (labelRegex.test(lines[i])) {
+        // Collect money tokens on same line
+        const same = Array.from(lines[i].matchAll(moneyRx)).map(m => m[0]);
+        if (same && same.length > 0) {
+          if (pick === 'second' && same.length >= 2) return parseMoneyStringToNumber(same[1]);
+          return parseMoneyStringToNumber(same[0]);
+        }
+        // Try next two lines for a plausible "current" amount
+        for (let j = 1; j <= 2 && i + j < lines.length; j++) {
+          const next = Array.from(lines[i + j].matchAll(moneyRx)).map(m => m[0]);
+          if (next && next.length > 0) {
+            if (pick === 'second' && next.length >= 2) return parseMoneyStringToNumber(next[1]);
+            return parseMoneyStringToNumber(next[0]);
+          }
+        }
+      }
+    }
+    return null;
+  }
+
+  function extractTaxSecondByPrefixes(prefixes) {
+    const rx = new RegExp(`^(?:${prefixes.map(p => p.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&")).join('|')})(?:[^\n]*)$`, 'i');
+    const moneyRx = /\(?-?\$?[0-9]{1,3}(?:,[0-9]{3})*(?:\.[0-9]{2})\)?|\(?-?[0-9]+(?:\.[0-9]{2})\)?/g;
+    for (const line of lines) {
+      if (rx.test(line)) {
+        const tokens = Array.from(line.matchAll(moneyRx)).map(m => m[0]);
+        if (tokens.length >= 2) return parseMoneyStringToNumber(tokens[1]);
+      }
+    }
+    return null;
+  }
+
+  // Amounts (summary) with broader synonyms and line scanning fallback
+  const grossPay = extractAmountByLabel(text, ["Gross Pay", "Current Gross"]) ||
+                   extractFromLines(["Gross Pay", "Current Gross"], 'first') ||
+                   extractFromLines(["Gross Earnings", "Total Earnings"], 'second');
+  const netPay = extractAmountByLabel(text, ["Net Pay", "Net Amount", "Net Check", "NET PAY"]) ||
+                 extractFromLines(["Net Pay", "Net Amount", "Net Check", "NET PAY"]);
+  const totalTaxes = extractAmountByLabel(text, ["Total Taxes", "Taxes Total", "Total Tax", "Employee Taxes", "Taxes"]) ||
+                     extractFromLines(["Total Taxes", "Taxes Total", "Total Tax", "Employee Taxes", "Taxes"]);
+  const totalDeductions = extractAmountByLabel(text, ["Total Deductions", "Deductions Total", "Total Deduction", "Employee Deductions", "Deductions"]) ||
+                          extractFromLines(["Total Deductions", "Deductions Total", "Total Deduction", "Employee Deductions", "Deductions"]);
+
+  // Common tax lines with more synonyms
+  const federalIncomeTax = extractTaxSecondByPrefixes(["FIT", "FITW", "FITWS"]) ||
+                           extractFromLines(["Federal Income Tax", "Federal Withholding", "Fed Income Tax", "Fed Withholding", "FIT"], 'second');
+  const stateIncomeTax = extractTaxSecondByPrefixes(["SIT", "CAS", "CAS-", "CA SIT", "CA STATE", "CA ST"]) ||
+                         extractFromLines(["State Income Tax", "State Withholding", "CA Withholding", "California Withholding", "SIT", "CAS"], 'second');
+  const socialSecurity = extractTaxSecondByPrefixes(["SS", "FICA Social Security", "OASDI"]) ||
+                         extractFromLines(["Social Security", "OASDI", "FICA Social Security", "Social Security Employee", "SS"], 'second');
+  const medicare = extractTaxSecondByPrefixes(["MED", "Medicare"]) ||
+                   extractFromLines(["Medicare", "FICA Medicare", "Medicare Employee", "MED"], 'second');
+
+  // Derive missing totals where possible
+  let derivedGross = grossPay;
+  let derivedTaxes = totalTaxes;
+  let derivedDeductions = totalDeductions;
+  const taxParts = [federalIncomeTax, stateIncomeTax, socialSecurity, medicare].filter(v => typeof v === 'number');
+  if (derivedTaxes == null && taxParts.length >= 1) {
+    derivedTaxes = taxParts.reduce((sum, v) => sum + v, 0);
+  }
+  if (derivedGross == null && typeof netPay === 'number' && typeof derivedTaxes === 'number' && typeof derivedDeductions === 'number') {
+    derivedGross = netPay + derivedTaxes + derivedDeductions;
+  }
+  if (derivedDeductions == null && typeof netPay === 'number' && typeof derivedTaxes === 'number' && typeof derivedGross === 'number') {
+    derivedDeductions = derivedGross - netPay - derivedTaxes;
+  }
+
+  return {
+    payDate,
+    periodStart,
+    periodEnd,
+    grossPay: derivedGross ?? null,
+    netPay,
+    totalTaxes: derivedTaxes ?? null,
+    totalDeductions: derivedDeductions ?? null,
+    federalIncomeTax,
+    stateIncomeTax,
+    socialSecurity,
+    medicare,
+  };
+}
+
+module.exports = {
+  parsePaylocityPaystub,
+  parseMoneyStringToNumber,
+  normalizeText,
+};
+
+


### PR DESCRIPTION
## Summary

feat(payroll): add Paylocity paychecks CLI and robust parser; docs and scripts; version 1.4.0\n\n- New CLI paylocity.js to parse a folder of Paylocity paycheck PDFs into a single CSV\n- Parser handles month-name/numeric dates, Period Beginning/Ending, parentheses/negative amounts, compact tax lines (FIT/SS/MED), and line-wrapped labels\n- Added --debug-text to dump normalized PDF text for troubleshooting\n- README overview updated; new tool documented\n- CHANGELOG for 1.4.0; package.json version bump and scriptd scripts; version 1.4.0\n\n- New CLI paylocity.js to parse a folder of Paylocity paycheck PDFs into a single CSV\n- Parser handles month-name/numeric dates, Period Beginning/Ending, parentheses/negative amounts, compact tax lines (FIT/SS/MED), and line-wrapped labels\n- Added --debug-text to dump normalized PDF text for troubleshooting\n- README overview updated; new tool documented\n- CHANGELOG for 1.4.0; package.json version bump and script

## Checklist (Repo Rules)

- [ ] package.json version bumped (SemVer)
- [ ] CHANGELOG.md updated with a new entry
- [ ] Changes are small and discrete (avoid large mixed commits)
- [ ] Tests updated/added as needed

## Notes

Link to relevant files (e.g., `output/`, `source_files/`) or artifacts if applicable.


