### PR TITLE
Ofw threading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,26 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [1.10.0] - 2025-08-15
 
-PR: [#18](https://github.com/jozecuervo/ofw-tools/pull/18)
-
 ### Added
-  - OFW:
-  - Added `assignThreads` function to assign threads to messages.
-  - Added `threadStats` to the output. (totals and weekly)
-  - Added `formatThreadStatsMarkdown` to the output.
-  - Added `formatThreadStatsCsv` to the output.
-  - Added `formatThreadStatsMarkdown` to the output.
+- OFW threading and summaries:
+  - Subject-based thread assignment with normalization (strips Re/Fwd, brackets) and participant keying
+  - Inactivity-based splitting: start a new thread segment when gap > 30 days; `threadKey` gets `#<segment>` suffix
+  - Per-message fields: `threadId`, `threadKey`, `threadIndex`
+  - Thread statistics computed in aggregator and exposed as `threadStats` (global and per-week)
+  - Weekly Markdown now includes a per-week summary row with “Threads” and “Avg Thread”
+  - Totals Markdown includes an in-table totals row and an all-time thread summary (total threads, average length)
+  - New Thread Tree Markdown output: `<report>.threads.md` with ASCII branch listing per message
+  - New Threads CSV output: `<report>-threads.csv` (Thread ID, Key, Subject, Messages, First/Last Sent, Span Days, Participants, Words, Avg Sentiment, Tone)
+    - Timestamps formatted as local `YYYY-MM-DD HH:MM`
+    - CSV cells escaped per RFC 4180
+
+### Changed
+- Read-time units computed in hours at aggregation time
+- Weekly senders CSV renamed to `<report>-senders.csv`
+- Top2 comparison CSV renamed to `<report>-top2-comparison.csv`
+
+### Tests
+- Added unit tests for thread assignment, inactivity split, thread tree, and threads CSV
 
 ## [1.9.0] - 2025-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [1.10.0] - 2025-08-15
+
+PR: [#18](https://github.com/jozecuervo/ofw-tools/pull/18)
+
+### Added
+  - OFW:
+  - Added `assignThreads` function to assign threads to messages.
+  - Added `threadStats` to the output. (totals and weekly)
+  - Added `formatThreadStatsMarkdown` to the output.
+  - Added `formatThreadStatsCsv` to the output.
+  - Added `formatThreadStatsMarkdown` to the output.
+
 ## [1.9.0] - 2025-08-12
 
 PR: [#17](https://github.com/jozecuervo/ofw-tools/pull/13)

--- a/__tests__/ofw-output.test.js
+++ b/__tests__/ofw-output.test.js
@@ -1,4 +1,4 @@
-const { formatMessageMarkdown, formatTotalsMarkdown, formatWeeklyMarkdown } = require('../utils/output/markdown');
+const { formatMessageMarkdown, formatTotalsMarkdown, formatWeeklyMarkdown, formatThreadTreeMarkdown } = require('../utils/output/markdown');
 const { formatWeeklyCsv, formatWeeklyTop2Csv } = require('../utils/output/csv');
 const { computeTone } = require('../utils/ofw/stats');
 
@@ -17,6 +17,18 @@ describe('utils/output', () => {
     expect(str).toMatch(/Message 1 of 1/);
     expect(str).toMatch(/Hello/);
     expect(str).toMatch(/World/);
+  });
+
+  test('formatThreadTreeMarkdown groups by thread and lists messages', () => {
+    const msgs = [
+      { threadId: 1, subject: 'Hello', sender: 'A', recipientReadTimes: {}, sentDate: new Date('2025-01-01T00:00:00'), body: 'First' },
+      { threadId: 1, subject: 'Re: Hello', sender: 'B', recipientReadTimes: {}, sentDate: new Date('2025-01-01T01:00:00'), body: 'Second' },
+      { threadId: 2, subject: 'Other', sender: 'C', recipientReadTimes: {}, sentDate: new Date('2025-01-02T00:00:00'), body: 'Third' },
+    ];
+    const md = formatThreadTreeMarkdown(msgs);
+    expect(md).toMatch(/# Threads/);
+    expect(md).toMatch(/Thread 1: Hello \(2\)/);
+    expect(md).toMatch(/Thread 2: Other \(1\)/);
   });
 
   test('formatWeeklyCsv outputs header and rows', () => {

--- a/__tests__/ofw-output.test.js
+++ b/__tests__/ofw-output.test.js
@@ -1,5 +1,6 @@
 const { formatMessageMarkdown, formatTotalsMarkdown, formatWeeklyMarkdown, formatThreadTreeMarkdown } = require('../utils/output/markdown');
-const { formatWeeklyCsv, formatWeeklyTop2Csv } = require('../utils/output/csv');
+const { formatWeeklyCsv, formatWeeklyTop2Csv, formatThreadsCsv } = require('../utils/output/csv');
+const { summarizeThreads } = require('../utils/ofw/threads');
 const { computeTone } = require('../utils/ofw/stats');
 
 describe('utils/output', () => {
@@ -17,6 +18,21 @@ describe('utils/output', () => {
     expect(str).toMatch(/Message 1 of 1/);
     expect(str).toMatch(/Hello/);
     expect(str).toMatch(/World/);
+  });
+
+  test('formatThreadsCsv emits one row per thread with participants', () => {
+    const msgs = [
+      { threadId: 1, subject: 'Hello', sender: 'A', recipientReadTimes: { B: 'Never' }, sentDate: new Date('2025-01-01T00:00:00'), body: 'First', wordCount: 5, sentiment: 0, tone: 0 },
+      { threadId: 1, subject: 'Re: Hello', sender: 'B', recipientReadTimes: { A: 'Never' }, sentDate: new Date('2025-01-01T01:00:00'), body: 'Second', wordCount: 4, sentiment: 0, tone: 0 },
+      { threadId: 2, subject: 'Other', sender: 'C', recipientReadTimes: {}, sentDate: new Date('2025-01-02T00:00:00'), body: 'Third', wordCount: 3, sentiment: 0, tone: 0 },
+    ];
+    const summaries = summarizeThreads(msgs);
+    const csv = formatThreadsCsv(summaries);
+    const lines = csv.trim().split('\n');
+    expect(lines[0]).toMatch(/Thread ID,Thread Key,Subject/);
+    expect(lines.length).toBe(1 + 2);
+    expect(csv).toMatch(/Hello/);
+    expect(csv).toMatch(/Other/);
   });
 
   test('formatThreadTreeMarkdown groups by thread and lists messages', () => {

--- a/__tests__/ofw-threads.test.js
+++ b/__tests__/ofw-threads.test.js
@@ -32,6 +32,24 @@ describe('utils/ofw/threads', () => {
     expect(hiThread.every(m => m.threadId === hiThread[0].threadId)).toBe(true);
     expect(hiThread.map(m => m.threadIndex)).toEqual([0, 1]);
   });
+
+  test('assignThreads splits long inactivity gaps into new segments', () => {
+    const day = 24 * 60 * 60 * 1000;
+    const base = new Date('2025-01-01T00:00:00Z').getTime();
+    const messages = assignThreads([
+      { sender: 'A', recipientReadTimes: { B: 'Never' }, subject: 'Hi', body: '1', sentDate: new Date(base + 0 * day) },
+      { sender: 'A', recipientReadTimes: { B: 'Never' }, subject: 're: hi', body: '2', sentDate: new Date(base + 1 * day) },
+      { sender: 'A', recipientReadTimes: { B: 'Never' }, subject: 're: hi', body: '3', sentDate: new Date(base + 70 * day) },
+    ], { inactivityDays: 30 });
+    const ids = messages.map(m => m.threadId);
+    // Expect a split after 70 days gap
+    expect(new Set(ids).size).toBe(2);
+    // And segment suffix in keys
+    const keys = messages.map(m => m.threadKey);
+    expect(keys[0]).toMatch(/#1$/);
+    expect(keys[1]).toMatch(/#1$/);
+    expect(keys[2]).toMatch(/#2$/);
+  });
 });
 
 

--- a/__tests__/ofw-threads.test.js
+++ b/__tests__/ofw-threads.test.js
@@ -1,0 +1,37 @@
+const { normalizeSubject, assignThreads, computeThreadKey } = require('../utils/ofw/threads');
+
+describe('utils/ofw/threads', () => {
+  test('normalizeSubject strips reply/forward prefixes and punctuation', () => {
+    expect(normalizeSubject('Re: Re: Update!!!')).toBe('update');
+    expect(normalizeSubject('FW:   [External] Notice - FYI')).toBe('notice fyi');
+    expect(normalizeSubject('   ')).toBe('no subject');
+  });
+
+  test('computeThreadKey includes participants and handles no subject by day', () => {
+    const base = { sender: 'Alice', recipientReadTimes: { Bob: new Date() } };
+    const m1 = { ...base, subject: 'Hello', sentDate: new Date('2025-01-01T10:00:00') };
+    const m2 = { ...base, subject: 're: hello', sentDate: new Date('2025-01-02T10:00:00') };
+    const k1 = computeThreadKey(m1);
+    const k2 = computeThreadKey(m2);
+    expect(k1).toBe(k2); // subject-based match
+
+    const n1 = { ...base, subject: 'No subject', sentDate: new Date('2025-01-01T12:00:00') };
+    const n2 = { ...base, subject: 'no subject', sentDate: new Date('2025-01-02T12:00:00') };
+    expect(computeThreadKey(n1)).not.toBe(computeThreadKey(n2)); // day bucketed
+  });
+
+  test('assignThreads assigns stable ids and indices', () => {
+    const messages = assignThreads([
+      { sender: 'A', recipientReadTimes: { B: 'Never' }, subject: 'Hi', body: '1', sentDate: new Date('2025-01-01T08:00:00') },
+      { sender: 'A', recipientReadTimes: { B: 'Never' }, subject: 're: hi', body: '2', sentDate: new Date('2025-01-01T09:00:00') },
+      { sender: 'A', recipientReadTimes: { B: 'Never' }, subject: 'Other', body: 'x', sentDate: new Date('2025-01-01T07:00:00') },
+    ]);
+    const ids = messages.map(m => m.threadId);
+    expect(new Set(ids).size).toBe(2);
+    const hiThread = messages.filter(m => m.subject.toLowerCase().includes('hi'));
+    expect(hiThread.every(m => m.threadId === hiThread[0].threadId)).toBe(true);
+    expect(hiThread.map(m => m.threadIndex)).toEqual([0, 1]);
+  });
+});
+
+

--- a/ofw.js
+++ b/ofw.js
@@ -148,11 +148,9 @@ function writeMarkDownFile(data) {
  * @param {Record<string, Record<string, any>>} stats - Per-week per-person stats
  */
 function outputMarkdownSummary(totals, stats, options = {}) {
-    console.log(formatTotalsMarkdown(totals, options));
     console.log(formatWeeklyMarkdown(stats, options));
+    console.log(formatTotalsMarkdown(totals, options));
 }
-
-
 
 /**
  * Write weekly stats to CSV.
@@ -188,8 +186,8 @@ function outputCsvWith(formatter, data, filePath, label = 'CSV') {
 function compileAndOutputStats({ messages, directory, fileNameWithoutExt }, options = { writeCsv: true, excludePatterns: [] }) {
     const { totals, weekly, threadStats } = accumulateStats(messages);
     const outDir = path.resolve(process.cwd(), 'output');
-    const csvFilePath = options.writeCsv && fileNameWithoutExt ? path.join(outDir, `${fileNameWithoutExt}.csv`) : null;
-    const top2CsvPath = options.writeCsv && fileNameWithoutExt ? path.join(outDir, `${fileNameWithoutExt}.top2.csv`) : null;
+    const csvFilePath = options.writeCsv && fileNameWithoutExt ? path.join(outDir, `${fileNameWithoutExt}-senders.csv`) : null;
+    const top2CsvPath = options.writeCsv && fileNameWithoutExt ? path.join(outDir, `${fileNameWithoutExt}-top2-comparison.csv`) : null;
     outputCsvWith(formatWeeklyCsv, weekly, csvFilePath, 'CSV');
     outputCsvWith(formatWeeklyTop2Csv, weekly, top2CsvPath, 'Top2 CSV');
     outputMarkdownSummary(totals, weekly, { excludePatterns: options.excludePatterns, threadStats });

--- a/ofw.js
+++ b/ofw.js
@@ -27,7 +27,8 @@ const { computeDerivedMetrics } = require('./utils/ofw/metrics');
 const { assignThreads } = require('./utils/ofw/threads');
 const { accumulateStats } = require('./utils/ofw/stats');
 const { formatMessageMarkdown, formatTotalsMarkdown, formatWeeklyMarkdown, formatThreadTreeMarkdown } = require('./utils/output/markdown');
-const { formatWeeklyCsv, formatWeeklyTop2Csv } = require('./utils/output/csv');
+const { formatWeeklyCsv, formatWeeklyTop2Csv, formatThreadsCsv } = require('./utils/output/csv');
+const { summarizeThreads } = require('./utils/ofw/threads');
 const { writeFile, writeJson } = require('./utils');
 
 /**
@@ -195,8 +196,11 @@ function compileAndOutputStats({ messages, directory, fileNameWithoutExt }, opti
     const outDir = path.resolve(process.cwd(), 'output');
     const csvFilePath = options.writeCsv && fileNameWithoutExt ? path.join(outDir, `${fileNameWithoutExt}-senders.csv`) : null;
     const top2CsvPath = options.writeCsv && fileNameWithoutExt ? path.join(outDir, `${fileNameWithoutExt}-top2-comparison.csv`) : null;
+    const threadsCsvPath = options.writeCsv && fileNameWithoutExt ? path.join(outDir, `${fileNameWithoutExt}-threads.csv`) : null;
     outputCsvWith(formatWeeklyCsv, weekly, csvFilePath, 'CSV');
     outputCsvWith(formatWeeklyTop2Csv, weekly, top2CsvPath, 'Top2 CSV');
+    const threadSummaries = summarizeThreads(messages);
+    outputCsvWith(formatThreadsCsv, threadSummaries, threadsCsvPath, 'Threads CSV');
     outputMarkdownSummary(totals, weekly, { excludePatterns: options.excludePatterns, threadStats });
 }
 

--- a/ofw.js
+++ b/ofw.js
@@ -201,7 +201,21 @@ function compileAndOutputStats({ messages, directory, fileNameWithoutExt }, opti
     outputCsvWith(formatWeeklyTop2Csv, weekly, top2CsvPath, 'Top2 CSV');
     const threadSummaries = summarizeThreads(messages);
     outputCsvWith(formatThreadsCsv, threadSummaries, threadsCsvPath, 'Threads CSV');
-    outputMarkdownSummary(totals, weekly, { excludePatterns: options.excludePatterns, threadStats });
+    // Augment threadStats with richer averages from summaries
+    const nThreads = threadSummaries.length || 0;
+    const sumMsgs = threadSummaries.reduce((a, t) => a + (Number(t.messages) || 0), 0);
+    const sumDays = threadSummaries.reduce((a, t) => a + (Number(t.spanDays) || 0), 0);
+    const sumWords = threadSummaries.reduce((a, t) => a + (Number(t.totalWords) || 0), 0);
+    const enrichedThreadStats = {
+      ...threadStats,
+      totals: {
+        ...(threadStats && threadStats.totals ? threadStats.totals : {}),
+        avgMessagesPerThread: nThreads ? Number((sumMsgs / nThreads).toFixed(2)) : 0,
+        avgDaysPerThread: nThreads ? Number((sumDays / nThreads).toFixed(2)) : 0,
+        avgWordsPerThread: nThreads ? Number((sumWords / nThreads).toFixed(2)) : 0,
+      },
+    };
+    outputMarkdownSummary(totals, weekly, { excludePatterns: options.excludePatterns, threadStats: enrichedThreadStats });
 }
 
 

--- a/ofw.js
+++ b/ofw.js
@@ -148,23 +148,8 @@ function writeMarkDownFile(data) {
  * @param {Record<string, Record<string, any>>} stats - Per-week per-person stats
  */
 function outputMarkdownSummary(totals, stats, options = {}) {
-    if (options && options.threadStats) {
-        const ts = options.threadStats;
-        if (ts && ts.totals) {
-            const avg = Number(ts.totals.averageThreadLength);
-            console.log(`Threads: ${ts.totals.totalThreads} (avg length: ${Number.isFinite(avg) ? avg.toFixed(2) : '0.00'})`);
-        }
-        if (ts && ts.weekly && typeof ts.weekly === 'object') {
-            console.log('Weekly thread summary:');
-            Object.keys(ts.weekly).forEach(week => {
-                const w = ts.weekly[week] || {};
-                const avgW = Number(w.averageThreadLength);
-                console.log(`- ${week}: ${w.totalThreads} threads, avg length ${Number.isFinite(avgW) ? avgW.toFixed(2) : '0.00'}`);
-            });
-        }
-    }
-    console.log(formatTotalsMarkdown(totals, options));
     console.log(formatWeeklyMarkdown(stats, options));
+    console.log(formatTotalsMarkdown(totals, options));
 }
 
 

--- a/ofw.js
+++ b/ofw.js
@@ -26,7 +26,7 @@ const { processMessages } = require('./utils/ofw/parser');
 const { computeDerivedMetrics } = require('./utils/ofw/metrics');
 const { assignThreads } = require('./utils/ofw/threads');
 const { accumulateStats } = require('./utils/ofw/stats');
-const { formatMessageMarkdown, formatTotalsMarkdown, formatWeeklyMarkdown } = require('./utils/output/markdown');
+const { formatMessageMarkdown, formatTotalsMarkdown, formatWeeklyMarkdown, formatThreadTreeMarkdown } = require('./utils/output/markdown');
 const { formatWeeklyCsv, formatWeeklyTop2Csv } = require('./utils/output/csv');
 const { writeFile, writeJson } = require('./utils');
 
@@ -135,6 +135,11 @@ function writeMarkDownFile(data) {
             const markdownFilePath = path.join(outDir, `${fileNameWithoutExt}.md`);
             console.log(`Writing all messages to ${markdownFilePath}`);
             writeFile(markdownFilePath, markdownContent);
+            // Also write thread tree view
+            const threadMd = formatThreadTreeMarkdown(messages);
+            const threadFilePath = path.join(outDir, `${fileNameWithoutExt}.threads.md`);
+            console.log(`Writing thread tree to ${threadFilePath}`);
+            writeFile(threadFilePath, threadMd);
             resolve(data);  // Pass the data object along for further processing
         } catch (error) {
             reject(`Failed to write Markdown file: ${error}`);
@@ -149,6 +154,8 @@ function writeMarkDownFile(data) {
  */
 function outputMarkdownSummary(totals, stats, options = {}) {
     console.log(formatWeeklyMarkdown(stats, options));
+    // output threaded message tree to console
+    // console.log(formatThreadStatsMarkdown(totals, options));
     console.log(formatTotalsMarkdown(totals, options));
 }
 

--- a/ofw.js
+++ b/ofw.js
@@ -148,8 +148,8 @@ function writeMarkDownFile(data) {
  * @param {Record<string, Record<string, any>>} stats - Per-week per-person stats
  */
 function outputMarkdownSummary(totals, stats, options = {}) {
-    console.log(formatWeeklyMarkdown(stats, options));
     console.log(formatTotalsMarkdown(totals, options));
+    console.log(formatWeeklyMarkdown(stats, options));
 }
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ofw-tools",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "This repository contains a set of small, focused tools that help analyze communications, plan visitation schedules, and perform basic family-law-related calculations (Moore/Marsden, apportionment). These are optimized for quick, local use as you prepare materials for court.",
   "main": "index.js",
   "scripts": {

--- a/utils/ofw/stats.js
+++ b/utils/ofw/stats.js
@@ -77,7 +77,8 @@ function accumulateStats(messages) {
     for (const [recipient, firstViewed] of Object.entries(message.recipientReadTimes)) {
       if (firstViewed !== 'Never') {
         const firstViewedDate = new Date(firstViewed);
-        const readTime = (firstViewedDate - message.sentDate) / 60000;
+        // Convert to hours at accumulation time (was minutes previously)
+        const readTime = (firstViewedDate - message.sentDate) / 3600000;
 
         if (!totals[recipient]) {
           totals[recipient] = {

--- a/utils/ofw/stats.js
+++ b/utils/ofw/stats.js
@@ -22,6 +22,17 @@ const defaultStats = {
 function accumulateStats(messages) {
   const stats = {};
   const totals = {};
+  // Thread tracking: global and per-week maps of threadKey -> count (within that scope)
+  const globalThreadCounts = new Map();
+  const weeklyThreadCounts = {}; // week -> Map
+
+  function getThreadKeyForStats(message) {
+    if (!message || typeof message !== 'object') return 'unknown';
+    if (message.threadId != null) return `id:${message.threadId}`;
+    if (message.threadKey) return `key:${String(message.threadKey)}`;
+    const subj = String(message.subject || '').toLowerCase().trim();
+    return `subj:${subj}`;
+  }
 
   messages.forEach(message => {
     if (message && (message._nonMessage || !message.sentDate || !message.sender)) {
@@ -29,6 +40,11 @@ function accumulateStats(messages) {
     }
     const weekString = getWeekString(message.sentDate);
     const sender = message.sender || 'Unknown';
+    // Ensure week thread map exists
+    if (!weeklyThreadCounts[weekString]) weeklyThreadCounts[weekString] = new Map();
+    const threadKey = getThreadKeyForStats(message);
+    weeklyThreadCounts[weekString].set(threadKey, (weeklyThreadCounts[weekString].get(threadKey) || 0) + 1);
+    globalThreadCounts.set(threadKey, (globalThreadCounts.get(threadKey) || 0) + 1);
 
     if (!totals[sender]) {
       totals[sender] = {
@@ -113,7 +129,29 @@ function accumulateStats(messages) {
     }
   }
 
-  return { totals, weekly: stats };
+  // Finalize thread metrics
+  const threadStatsWeekly = {};
+  Object.entries(weeklyThreadCounts).forEach(([week, map]) => {
+    const counts = Array.from(map.values());
+    const totalThreads = counts.length;
+    const avg = counts.length ? counts.reduce((a, b) => a + b, 0) / counts.length : 0;
+    threadStatsWeekly[week] = {
+      totalThreads,
+      averageThreadLength: Number.isFinite(avg) ? Number(avg.toFixed(2)) : 0,
+    };
+  });
+  const globalCounts = Array.from(globalThreadCounts.values());
+  const globalTotalThreads = globalCounts.length;
+  const globalAvg = globalCounts.length ? globalCounts.reduce((a, b) => a + b, 0) / globalCounts.length : 0;
+  const threadStats = {
+    totals: {
+      totalThreads: globalTotalThreads,
+      averageThreadLength: Number.isFinite(globalAvg) ? Number(globalAvg.toFixed(2)) : 0,
+    },
+    weekly: threadStatsWeekly,
+  };
+
+  return { totals, weekly: stats, threadStats };
 }
 
 // Compute tone as weekly/total average of per-message tone (computed in metrics)

--- a/utils/ofw/threads.js
+++ b/utils/ofw/threads.js
@@ -1,0 +1,117 @@
+/**
+ * Thread assignment for OFW messages.
+ * Strategy: subject-based normalization with participant set and safeguards for "No subject".
+ */
+
+function normalizeWhitespace(input) {
+  return String(input || '')
+    .replace(/[\u00A0\u200E\u200F]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Remove common reply/forward prefixes and normalize subject for grouping.
+ * Examples: "Re: Re: Update" -> "update"; "FW: Notice" -> "notice".
+ */
+function normalizeSubject(subjectRaw) {
+  let s = normalizeWhitespace(subjectRaw).toLowerCase();
+  // Iteratively remove prefixes like re:, fw:, fwd:
+  // Limit loops to prevent pathological cases
+  for (let i = 0; i < 5; i++) {
+    const next = s.replace(/^(re|fw|fwd)\s*:\s*/i, '');
+    if (next === s) break;
+    s = next;
+  }
+  // After removing prefixes, strip one or more leading bracket tags like [External]
+  for (let i = 0; i < 5; i++) {
+    const next = s.replace(/^\[[^\]]+\]\s*/i, '');
+    if (next === s) break;
+    s = next;
+  }
+  // Collapse punctuation that rarely differentiates threads
+  s = s.replace(/[\-–—_~*\[\](){}<>"'`.,!?#:;]+/g, ' ');
+  s = s.replace(/\s+/g, ' ').trim();
+  return s || 'no subject';
+}
+
+function getParticipants(message) {
+  const participants = new Set();
+  if (message && message.sender) participants.add(String(message.sender).trim());
+  if (message && message.recipientReadTimes && typeof message.recipientReadTimes === 'object') {
+    Object.keys(message.recipientReadTimes).forEach(name => {
+      if (name) participants.add(String(name).trim());
+    });
+  }
+  return Array.from(participants).sort((a, b) => a.localeCompare(b));
+}
+
+function yyyymmdd(date) {
+  if (!(date instanceof Date) || isNaN(date.getTime())) return 'unknown';
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+/**
+ * Compute a stable thread key for a message using subject and participants.
+ * For "no subject", include the day to avoid over-grouping across long timespans.
+ */
+function computeThreadKey(message) {
+  const subjectNorm = normalizeSubject(message && message.subject);
+  const participants = getParticipants(message).join('|');
+  if (subjectNorm === 'no subject') {
+    const day = yyyymmdd(message && message.sentDate);
+    return `nosubj|${day}|${participants}`;
+  }
+  return `${subjectNorm}|${participants}`;
+}
+
+/**
+ * Assign thread identifiers to messages in-place and return the same array for convenience.
+ * Adds: message.threadId (number), message.threadKey (string), message.threadIndex (0-based order within thread)
+ *
+ * @param {Array<object>} messages
+ * @returns {Array<object>}
+ */
+function assignThreads(messages) {
+  if (!Array.isArray(messages)) return [];
+  const keyToId = new Map();
+  const idToMessages = new Map();
+  let nextId = 1;
+
+  // First pass: compute keys and ids
+  messages.forEach(msg => {
+    if (!msg || typeof msg !== 'object') return;
+    const key = computeThreadKey(msg);
+    let id = keyToId.get(key);
+    if (!id) {
+      id = nextId++;
+      keyToId.set(key, id);
+      idToMessages.set(id, []);
+    }
+    msg.threadKey = key;
+    msg.threadId = id;
+    idToMessages.get(id).push(msg);
+  });
+
+  // Second pass: assign index within each thread by sentDate then stable fallback
+  idToMessages.forEach(list => {
+    list.sort((a, b) => {
+      const at = a && a.sentDate instanceof Date ? a.sentDate.getTime() : 0;
+      const bt = b && b.sentDate instanceof Date ? b.sentDate.getTime() : 0;
+      if (at !== bt) return at - bt;
+      const abody = String(a && a.body || '');
+      const bbody = String(b && b.body || '');
+      return abody.localeCompare(bbody);
+    });
+    list.forEach((m, idx) => { m.threadIndex = idx; });
+  });
+
+  return messages;
+}
+
+module.exports = { normalizeSubject, assignThreads, computeThreadKey };
+
+

--- a/utils/output/csv.js
+++ b/utils/output/csv.js
@@ -78,8 +78,14 @@ function getGlobalTopNSenders(stats, n) {
 
 function csvCell(val) {
   if (val === null || val === undefined) return '';
-  if (typeof val === 'string') return `"${val}"`;
-  return String(val);
+  const s = typeof val === 'string' ? val : String(val);
+  // Escape double quotes by doubling them per RFC 4180
+  const escaped = s.replace(/"/g, '""');
+  // Quote if the cell contains special characters
+  if (/[",\n\r]/.test(escaped)) {
+    return `"${escaped}"`;
+  }
+  return escaped;
 }
 
 function safeInt(val) {
@@ -93,3 +99,41 @@ function safeNum(val) {
 }
 
 module.exports.formatWeeklyTop2Csv = formatWeeklyTop2Csv;
+
+// Threads CSV: one row per thread with summary metrics
+function formatThreadsCsv(threadSummaries) {
+  const header = [
+    'Thread ID','Thread Key','Subject','Messages','First Sent','Last Sent','Span Days','Participants','Total Words','Avg Sentiment','Tone'
+  ].join(',');
+  const rows = [header];
+  const toLocalYMDHM = (val) => {
+    if (!val) return '';
+    const d = (val instanceof Date) ? val : new Date(val);
+    if (!(d instanceof Date) || isNaN(d.getTime())) return '';
+    const yyyy = d.getFullYear();
+    const mm = String(d.getMonth() + 1).padStart(2, '0');
+    const dd = String(d.getDate()).padStart(2, '0');
+    const hh = String(d.getHours()).padStart(2, '0');
+    const min = String(d.getMinutes()).padStart(2, '0');
+    return `${yyyy}-${mm}-${dd} ${hh}:${min}`;
+  };
+  (threadSummaries || []).forEach(t => {
+    const cells = [
+      t.threadId,
+      csvCell(t.threadKey || ''),
+      csvCell(t.subject || ''),
+      safeInt(t.messages),
+      csvCell(toLocalYMDHM(t.firstSentISO || '')),
+      csvCell(toLocalYMDHM(t.lastSentISO || '')),
+      safeNum(t.spanDays),
+      csvCell((t.participants || []).join('; ')),
+      safeInt(t.totalWords),
+      safeNum(t.avgSentiment),
+      safeNum(t.tone),
+    ];
+    rows.push(cells.join(','));
+  });
+  return rows.join('\n') + '\n';
+}
+
+module.exports.formatThreadsCsv = formatThreadsCsv;

--- a/utils/output/csv.js
+++ b/utils/output/csv.js
@@ -36,10 +36,11 @@ function formatWeeklyTop2Csv(stats) {
     const a = w[nameA] || {};
     const b = w[nameB] || {};
     const { startISO } = parseWeekLabelToStartEnd(week);
+    const weekLabel = startISO || week; // Fallback to original label if not parseable
     const toneA = (w[nameA] && Number.isFinite(Number(w[nameA].tone))) ? w[nameA].tone : 0;
     const toneB = (w[nameB] && Number.isFinite(Number(w[nameB].tone))) ? w[nameB].tone : 0;
     const row = [
-      startISO,
+      weekLabel,
       safeInt(a.messagesSent),
       safeInt(b.messagesSent),
       safeInt(a.totalWords),

--- a/utils/output/markdown.js
+++ b/utils/output/markdown.js
@@ -32,7 +32,7 @@ function formatMessageMarkdown(message, index, total) {
     `- From: **${sender}** ${formatDate(sentDate)}`,
     `- To:`,
     toLines,
-    `- Message **${index + 1}** of **${total}**`,
+    `- Message ${index + 1} of ${total}`,
     `- Word Count: **${wordCount}**, Sentiment: **${sentiment}**, Natural: **${sentiment_natural}**, Tone: **${tone}**`,
     '',
     body || '',

--- a/utils/output/markdown.js
+++ b/utils/output/markdown.js
@@ -82,7 +82,13 @@ function formatTotalsMarkdown(totals, options = {}) {
   out.push(totalsRow);
   out.push(separator);
   if (ts) {
-    out.push(`All-time totals —  Threads: ${ts.totalThreads}, Avg Thread Length: ${Number(ts.averageThreadLength).toFixed(2)}`);
+    const parts = [
+      `Threads: ${ts.totalThreads}`,
+      `Avg Messages / Thread: ${Number(ts.averageThreadLength).toFixed(2)}`,
+    ];
+    if (typeof ts.avgDaysPerThread === 'number') parts.push(`Avg days per thread: ${Number(ts.avgDaysPerThread).toFixed(2)}`);
+    if (typeof ts.avgWordsPerThread === 'number') parts.push(`Avg words per thread: ${Number(ts.avgWordsPerThread).toFixed(0)}`);
+    out.push(`All-time totals —  ${parts.join(', ')}`);
     out.push('');
   }
   out.push('\n');

--- a/utils/output/markdown.js
+++ b/utils/output/markdown.js
@@ -69,12 +69,20 @@ function formatTotalsMarkdown(totals, options = {}) {
     const row = `| ${paddedName} |${paddedSent} |${wordCountDisplay} |${paddedTotalTime} |${paddedAvgTime} | ${paddedSentiment} | ${paddedSentiment_natural} |`;
     out.push(row);
   }
+  // Totals row inside the table for Messages and Words
+  out.push(separator);
+  const nameBlank = ''.padEnd(16);
+  const sentTotal = String(totalMessages).padStart(5);
+  const wordsTotal = String(totalWords).padStart(6);
+  const totalTimeBlank = ''.padStart(10);
+  const avgTimeBlank = ''.padStart(14);
+  const avgSentBlank = ''.padStart(14);
+  const avgNatBlank = ''.padStart(14);
+  const totalsRow = `| ${nameBlank} |${sentTotal} |${wordsTotal} |${totalTimeBlank} |${avgTimeBlank} | ${avgSentBlank} | ${avgNatBlank} |`;
+  out.push(totalsRow);
   out.push(separator);
   if (ts) {
-    out.push(`All-time totals — Messages: ${totalMessages}, Threads: ${ts.totalThreads}, Avg Thread Length: ${Number(ts.averageThreadLength).toFixed(2)}, Words: ${totalWords}`);
-    out.push('');
-  } else {
-    out.push(`All-time totals — Messages: ${totalMessages}, Words: ${totalWords}`);
+    out.push(`All-time totals —  Threads: ${ts.totalThreads}, Avg Thread Length: ${Number(ts.averageThreadLength).toFixed(2)}`);
     out.push('');
   }
   out.push('\n');
@@ -102,7 +110,7 @@ function formatWeeklyMarkdown(stats, options = {}) {
       const paddedSentiment = personStats.avgSentiment.toFixed(2).toString().padStart(14);
       const naturalAvg = (personStats.avgSentimentNatural !== undefined) ? personStats.avgSentimentNatural : personStats.sentiment_natural;
       const paddedSentiment_natural = Number(naturalAvg).toFixed(2).toString().padStart(14);
-      const row = `| ${paddedWeek} | ${paddedName} |${paddedSent} |${wordCountDisplay} |${paddedAvgTime} | ${paddedSentiment} | ${paddedSentiment_natural} |`;
+      const row = `| ${paddedWeek} | ${paddedName} |${paddedSent} |${wordCountDisplay} |${paddedAvgTime} | ${paddedSentiment} | ${paddedSentiment_natural} | ${''.padStart(7)} | ${''.padStart(10)} |`;
       out.push(row);
       previousWeek = week;
     }

--- a/utils/output/markdown.js
+++ b/utils/output/markdown.js
@@ -50,8 +50,8 @@ function formatTotalsMarkdown(totals, options = {}) {
   const totalWords = entries.reduce((acc, [, t]) => acc + (t && t.totalWords ? t.totalWords : 0), 0);
   const ts = options && options.threadStats && options.threadStats.totals ? options.threadStats.totals : null;
   
-  let header = '| Name             | Sent | Words | View Time | Avg View Time | Avg. Sentiment | Sentiment ntrl |';
-  let separator = '|------------------|------|-------|-----------|---------------|----------------|----------------|';
+  let header = '| Name             | Sent | Words | View Time (hrs) | Avg View Time (hrs) | Avg. Sentiment | Sentiment ntrl |';
+  let separator = '|------------------|------|-------|-----------------|---------------------|----------------|----------------|';
   out.push('\n');
   out.push(separator);
   out.push(header);
@@ -60,8 +60,8 @@ function formatTotalsMarkdown(totals, options = {}) {
     if (shouldHide(person)) continue;
     const paddedName = person.padEnd(16);
     const paddedSent = personTotals.messagesSent.toString().padStart(5);
-    const paddedTotalTime = (personTotals.totalReadTime).toFixed(1).toString().padStart(10);
-    const paddedAvgTime = (personTotals.averageReadTime).toFixed(1).toString().padStart(14);
+    const paddedTotalTime = (personTotals.totalReadTime).toFixed(1).toString().padStart(16);
+    const paddedAvgTime = (personTotals.averageReadTime).toFixed(1).toString().padStart(20);
     const wordCountDisplay = personTotals.messagesSent > 0 ? personTotals.totalWords.toString().padStart(6) : ' '.padStart(6);
     const paddedSentiment = personTotals.avgSentiment.toFixed(2).toString().padStart(14);
     const naturalAvg = (personTotals.avgSentimentNatural !== undefined) ? personTotals.avgSentimentNatural : personTotals.sentiment_natural;
@@ -74,8 +74,8 @@ function formatTotalsMarkdown(totals, options = {}) {
   const nameBlank = ''.padEnd(16);
   const sentTotal = String(totalMessages).padStart(5);
   const wordsTotal = String(totalWords).padStart(6);
-  const totalTimeBlank = ''.padStart(10);
-  const avgTimeBlank = ''.padStart(14);
+  const totalTimeBlank = ''.padStart(16);
+  const avgTimeBlank = ''.padStart(20);
   const avgSentBlank = ''.padStart(14);
   const avgNatBlank = ''.padStart(14);
   const totalsRow = `| ${nameBlank} |${sentTotal} |${wordsTotal} |${totalTimeBlank} |${avgTimeBlank} | ${avgSentBlank} | ${avgNatBlank} |`;


### PR DESCRIPTION
## Summary


## [1.10.0] - 2025-08-15

### Added
- OFW threading and summaries:
  - Subject-based thread assignment with normalization (strips Re/Fwd, brackets) and participant keying
  - Inactivity-based splitting: start a new thread segment when gap > 30 days; `threadKey` gets `#<segment>` suffix
  - Per-message fields: `threadId`, `threadKey`, `threadIndex`
  - Thread statistics computed in aggregator and exposed as `threadStats` (global and per-week)
  - Weekly Markdown now includes a per-week summary row with “Threads” and “Avg Thread”
  - Totals Markdown includes an in-table totals row and an all-time thread summary (total threads, average length)
  - New Thread Tree Markdown output: `<report>.threads.md` with ASCII branch listing per message
  - New Threads CSV output: `<report>-threads.csv` (Thread ID, Key, Subject, Messages, First/Last Sent, Span Days, Participants, Words, Avg Sentiment, Tone)
    - Timestamps formatted as local `YYYY-MM-DD HH:MM`
    - CSV cells escaped per RFC 4180

### Changed
- Read-time units computed in hours at aggregation time
- Weekly senders CSV renamed to `<report>-senders.csv`
- Top2 comparison CSV renamed to `<report>-top2-comparison.csv`

### Tests
- Added unit tests for thread assignment, inactivity split, thread tree, and threads CSV

<img width="1486" height="778" alt="image" src="https://github.com/user-attachments/assets/f224fc85-fca0-4c39-9ca9-f57d11d409f7" />

## Checklist (Repo Rules)

- [ ] package.json version bumped (SemVer)
- [ ] CHANGELOG.md updated with a new entry
- [ ] Changes are small and discrete (avoid large mixed commits)
- [ ] Tests updated/added as needed

## Notes

Link to relevant files (e.g., `output/`, `source_files/`) or artifacts if applicable.


