### PR TITLE
Ollama sentiment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 # Temporary AI-generated prompt artifacts
 prompts/temp-*
 source_files
+*.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
-## [Unreleased]
+## [1.11.0] - 2025-08-15
+
+PR: [#19](https://github.com/jozecuervo/ofw-tools/pull/19)
 
 ### Added
 - Optional Ollama-based LLM sentiment post-processing for OFW analysis:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ PR: [#19](https://github.com/jozecuervo/ofw-tools/pull/19)
 ### Changed
 - CLI help updated to document `--ollama`
 - CLI argument parsing made order-agnostic for input file (first non-flag token)
+ - Prompt tuned for high-conflict and deception detection; JSON output schema captured when available
 
 ### Dependencies
 - Added `ollama`, `fs-extra`, and `winston`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [Unreleased]
+
+### Added
+- Optional Ollama-based LLM sentiment post-processing for OFW analysis:
+  - New flag `--ollama` on `ofw.js` to re-process the generated JSON with a local LLM
+  - New module `ollama-sentiment.js` implementing context-aware sentiment with limited thread context (default 3 prior messages)
+  - Outputs written alongside the original JSON in `./output/`:
+    - `<report> - LLM processed.json` (adds `sentiment_ollama` per message)
+    - `<report> - summary.md` (thread summaries with per-message sentiments and overall counts)
+- NPM script: `ofw:analyze-ollama` → `node ofw.js --ollama`
+
+### Changed
+- CLI help updated to document `--ollama`
+- CLI argument parsing made order-agnostic for input file (first non-flag token)
+
+### Dependencies
+- Added `ollama`, `fs-extra`, and `winston`
+
+### Notes
+- Requires a local Ollama server and model: `ollama pull llama3.1` and `ollama serve`
+- CommonJS import uses the ESM default export: `const { default: ollama } = require('ollama')`
+
 ## [1.10.0] - 2025-08-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 ## OFW Tools: Divorce and Communication Analysis Toolkit
 
-### ⚠️ IMPORTANT LEGAL DISCLAIMER
-
-**This toolkit is for educational and calculation purposes only and does not constitute legal advice.** Property division, family law issues, and communication analysis involve complex legal and factual determinations that vary by jurisdiction and individual circumstances. Always consult with a qualified family law attorney before making decisions based on these calculations or analysis. The tools do not account for many factors that may affect legal outcomes, including transmutations, agreements, refinances, improvements, or other legal doctrines.
-
 ### Overview
 
 Local-first Node.js CLIs that streamline common family-law workflows. These tools help you quickly analyze communications, generate calendars, compute property/equity figures, and now parse paychecks — all on your machine for privacy and speed. Outputs favor simple formats (CSV/Markdown/JSON) that drop easily into exhibits or spreadsheets.
@@ -433,3 +429,8 @@ You can also use these prompts to guide code generation, reviews, and testing ta
 ### Licensing
 
 Prompts are governed by `PROMPTS_LICENSE.md` and may differ from the code license.
+
+
+### ⚠️ IMPORTANT LEGAL DISCLAIMER
+
+**This toolkit is for educational and calculation purposes only and does not constitute legal advice.** Property division, family law issues, and communication analysis involve complex legal and factual determinations that vary by jurisdiction and individual circumstances. Always consult with a qualified family law attorney before making decisions based on these calculations or analysis. The tools do not account for many factors that may affect legal outcomes, including transmutations, agreements, refinances, improvements, or other legal doctrines.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Design principles:
 ### Quick Start
 
 - **Requirements**: Node.js (use your local `nvm` setup)
+  - Optional (for LLM sentiment post-processing): Ollama installed and running locally
+    - Pull model once: `ollama pull llama3.1`
+    - Run server: `ollama serve`
 - **Install**:
   ```bash
   cd ~/projects/ofw-tools
@@ -41,6 +44,7 @@ Design principles:
 Pass arguments after `--`.
 
 - Analyze OFW PDF: `npm run ofw:analyze -- /absolute/path/to/OFW_Messages_Report.pdf`
+- Analyze OFW PDF + LLM sentiment (Ollama): `npm run ofw:analyze-ollama -- /absolute/path/to/OFW_Messages_Report.pdf`
 - Rapid-fire clusters from JSON: `npm run ofw:clusters -- /absolute/path/to/OFW_Messages_Report.json`
 - Visitation calendar (YYYY MM): `npm run visitation -- 2024 4`
 - Fifth-week counter (built-in examples): `npm run nth-week`
@@ -72,10 +76,48 @@ Pass arguments after `--`.
   - `--no-markdown`: Skip writing per-message Markdown file
   - `--no-csv`: Skip writing weekly CSV
   - `--exclude <csv>`: Hide names containing any of the given substrings (case-insensitive) in printed tables
+  - `--ollama`: After JSON is written, perform LLM-based sentiment post-processing (requires local Ollama)
+  - `--ollama-max <n>`: Limit how many messages are sent to the LLM (default: 6)
 - **Display**:
   - “To:” pseudo-rows (recipient read-time buckets) are hidden in tables but still used for read-time stats.
   - Avg sentiment prints 0.00 when no messages were sent for that row/week.
   - Page banners and footers are excluded from message bodies.
+
+#### Ollama LLM Sentiment Post-Processing (Optional)
+
+- **Purpose**: Enhance sentiment with thread context and detect high-conflict/deceptive language indicators.
+- **Requirements**: Local Ollama with model `llama3.1` downloaded and server running.
+  ```bash
+  ollama pull llama3.1
+  ollama serve
+  ```
+- **Run**:
+  ```bash
+  # Default cap (6 messages sent to LLM)
+  npm run ofw:analyze-ollama -- /absolute/path/to/OFW_Messages_Report.pdf
+
+  # Override cap
+  node ofw.js /absolute/path/to/OFW_Messages_Report.pdf --ollama --ollama-max 24
+  ```
+- **Outputs** (written to `./output/` alongside the original JSON):
+  - `<report> - LLM processed.json` — same messages with an added `sentiment_ollama` field per message
+  - `<report> - summary.md` — per-thread list of messages and detected indicators
+- **`sentiment_ollama` schema** (compact JSON):
+  ```json
+  {
+    "sentiment": "positive|neutral|negative|mixed",
+    "conflict_level": "low|medium|high",
+    "deception_risk": "low|medium|high",
+    "flags": [
+      "insult","threat","gaslighting","darvo","blame-shift","minimization",
+      "legal-threat","coercion","manipulation","profanity","boundary-violation",
+      "inconsistency","false-allegation","exaggerated-absolutes"
+    ],
+    "reason": "Short justification"
+  }
+  ```
+  If the model returns non-JSON, the tool attempts to extract JSON; otherwise it stores a minimal object with a `raw` field.
+- **Bias testing**: The prompt includes baseline heuristic scores (`sentiment`, `sentiment_natural`, `tone`, and per‑word variants) for the current and prior context messages. This enables observing any systematic drift/bias when the model sees these priors versus when it does not (toggle by editing `ollama-sentiment.js`).
 
 ### 2) Rapid-Fire Message Clusters (`message-volume.js`)
 - **Purpose**: From the JSON produced by the OFW PDF Analyzer, find clusters of back-to-back messages within a time threshold (default 30 minutes) for a given sender.

--- a/ollama-sentiment.js
+++ b/ollama-sentiment.js
@@ -244,6 +244,11 @@ Output: {"sentiment":"negative","conflict_level":"high","deception_risk":"medium
 							conflict_level: stored.conflict_level,
 							deception_risk: stored.deception_risk,
 							flags: stored.flags,
+							baseline_sentiment: typeof message.sentiment === 'number' ? message.sentiment : null,
+							baseline_sentiment_natural: typeof message.sentiment_natural === 'number' ? message.sentiment_natural : null,
+							baseline_tone: typeof message.tone === 'number' ? message.tone : null,
+							baseline_spw: typeof message.sentiment_per_word === 'number' ? message.sentiment_per_word : null,
+							baseline_npw: typeof message.natural_per_word === 'number' ? message.natural_per_word : null,
 							threadIndex: message.threadIndex,
 						});
 						logger.info(`Processed message threadId:${threadId}, index:${message.threadIndex}`);
@@ -265,7 +270,15 @@ Output: {"sentiment":"negative","conflict_level":"high","deception_risk":"medium
 					}
 
 					const stored = normalizeOllamaOutput(parsed, result, message, threadContexts[threadId]);
-					this.updatedMessages.push({ ...message, sentiment_ollama: stored });
+					this.updatedMessages.push({
+						...message,
+						sentiment_ollama: stored,
+						baseline_sentiment: typeof message.sentiment === 'number' ? message.sentiment : null,
+						baseline_sentiment_natural: typeof message.sentiment_natural === 'number' ? message.sentiment_natural : null,
+						baseline_tone: typeof message.tone === 'number' ? message.tone : null,
+						baseline_spw: typeof message.sentiment_per_word === 'number' ? message.sentiment_per_word : null,
+						baseline_npw: typeof message.natural_per_word === 'number' ? message.natural_per_word : null,
+					});
 					threadContexts[threadId].push(message);
 					processed += 1;
 				} catch (error) {

--- a/ollama-sentiment.js
+++ b/ollama-sentiment.js
@@ -1,0 +1,201 @@
+const { default: ollama } = require('ollama');
+const fs = require('fs-extra');
+const path = require('path');
+const { createLogger, format, transports } = require('winston');
+
+// Configure logging
+const logger = createLogger({
+	level: 'info',
+	format: format.combine(format.timestamp(), format.json()),
+	transports: [new transports.Console(), new transports.File({ filename: 'process.log' })],
+});
+
+class MessageProcessor {
+	constructor(modelName = 'llama3.1', contextLimit = 3) {
+		this.modelName = modelName;
+		this.contextLimit = contextLimit; // Limit context to last N messages in thread to avoid excessive prompt length
+		this.results = {};
+		this.updatedMessages = [];
+		this.threadSummaries = {};
+	}
+
+	async processMessage(message, contextMessages = []) {
+		const prompt = 'Analyze the sentiment of the current message (positive, negative, or neutral) and provide a brief explanation, considering the context of prior messages. Respond strictly with one of: "positive", "negative", or "neutral" followed by a colon and a short reason.';
+		try {
+			// Limit context to avoid overwhelming the model
+			const context = contextMessages
+				.slice(-this.contextLimit)
+				.map(msg => `Previous message: ${msg.body}`)
+				.join('\n');
+			const fullPrompt = `${prompt}\n\nContext:\n${context ? context + '\n' : ''}Current message: ${message.body}`;
+
+			const response = await ollama.chat({
+				model: this.modelName,
+				messages: [{ role: 'user', content: fullPrompt }],
+			});
+			const result = (response && response.message && response.message.content ? response.message.content : '').trim();
+			logger.info(`Successfully processed message threadId:${message.threadId}, index:${message.threadIndex}`);
+			return result;
+		} catch (error) {
+			logger.error(`Error processing message threadId:${message.threadId}, index:${message.threadIndex}: ${error.message}`);
+			return null;
+		}
+	}
+
+	organizeMessages(messages) {
+		const threads = {};
+		for (const msg of messages) {
+			const threadId = msg.threadId;
+			if (!threads[threadId]) threads[threadId] = [];
+			threads[threadId].push(msg);
+		}
+
+		for (const threadId in threads) {
+			threads[threadId].sort((a, b) => new Date(a.sentDate) - new Date(b.sentDate));
+			this.threadSummaries[threadId] = {
+				messages: [],
+				subject: threads[threadId][0].subject,
+				participants: [
+					...new Set(
+						threads[threadId].flatMap(msg => [msg.sender, ...Object.keys(msg.recipientReadTimes || {})])
+					),
+				],
+			};
+		}
+
+		return Object.values(threads).flat();
+	}
+
+	async processJsonFile(inputFile, outputDir = 'output', options = {}) {
+		const { maxMessages } = { maxMessages: Infinity, ...options };
+		try {
+			const messages = await fs.readJson(inputFile);
+			if (!messages.length) {
+				logger.warn(`No messages found in ${inputFile}`);
+				return;
+			}
+
+			await fs.ensureDir(outputDir);
+			logger.info(`Found ${messages.length} messages across ${new Set(messages.map(m => m.threadId)).size} threads`);
+
+			const orderedMessages = this.organizeMessages(messages);
+			const threadContexts = {};
+
+			let processed = 0;
+			for (const message of orderedMessages) {
+				if (processed >= maxMessages) {
+					logger.info(`Reached maxMessages limit (${maxMessages}). Stopping early.`);
+					break;
+				}
+				const threadId = message.threadId;
+				if (!threadContexts[threadId]) threadContexts[threadId] = [];
+
+				try {
+					const result = await this.processMessage(message, threadContexts[threadId]);
+					const key = `${threadId}_${message.threadIndex}`;
+					if (result) {
+						this.results[key] = {
+							status: 'success',
+							sentiment: result,
+							threadId,
+							threadIndex: message.threadIndex,
+						};
+						this.threadSummaries[threadId].messages.push({
+							sender: message.sender,
+							sentDate: message.sentDate,
+							body: message.body,
+							sentiment: result,
+							threadIndex: message.threadIndex,
+						});
+						logger.info(`Processed message threadId:${threadId}, index:${message.threadIndex}`);
+					} else {
+						this.results[key] = {
+							status: 'failed',
+							error: 'No result returned',
+							threadId,
+							threadIndex: message.threadIndex,
+						};
+						this.threadSummaries[threadId].messages.push({
+							sender: message.sender,
+							sentDate: message.sentDate,
+							body: message.body,
+							sentiment: 'Failed to process',
+							threadIndex: message.threadIndex,
+						});
+						logger.error(`Failed to process message threadId:${threadId}, index:${message.threadIndex}`);
+					}
+
+					this.updatedMessages.push({ ...message, sentiment_ollama: result || 'Failed to process' });
+					threadContexts[threadId].push(message);
+					processed += 1;
+				} catch (error) {
+					this.results[`${threadId}_${message.threadIndex}`] = {
+						status: 'error',
+						error: error.message,
+						threadId,
+						threadIndex: message.threadIndex,
+					};
+					this.threadSummaries[threadId].messages.push({
+						sender: message.sender,
+						sentDate: message.sentDate,
+						body: message.body,
+						sentiment: `Error: ${error.message}`,
+						threadIndex: message.threadIndex,
+					});
+					this.updatedMessages.push({ ...message, sentiment_ollama: `Error: ${error.message}` });
+					logger.error(`Error processing message threadId:${threadId}, index:${message.threadIndex}: ${error.message}`);
+					processed += 1;
+				}
+			}
+
+			const inputBase = path.basename(inputFile, path.extname(inputFile));
+			const outputJson = path.join(outputDir, `${inputBase} - LLM processed.json`);
+			await fs.writeJson(outputJson, this.updatedMessages, { spaces: 2 });
+			logger.info(`Saved updated JSON to ${outputJson}`);
+
+			const summaryFile = path.join(outputDir, `${inputBase} - summary.md`);
+			const summaryContent = this.generateSummaryMarkdown();
+			await fs.writeFile(summaryFile, summaryContent);
+			logger.info(`Saved summary to ${summaryFile}`);
+		} catch (error) {
+			logger.error(`Error reading file ${inputFile}: ${error.message}`);
+		}
+	}
+
+	generateSummaryMarkdown() {
+		let markdown = '# Sentiment Analysis Summary\n\n';
+		const sentiments = { positive: 0, negative: 0, neutral: 0 };
+
+		for (const threadId in this.threadSummaries) {
+			const thread = this.threadSummaries[threadId];
+			markdown += `## Thread ${threadId}: ${thread.subject}\n`;
+			markdown += `- **Participants**: ${thread.participants.join(', ')}\n`;
+			markdown += `- **Message Count**: ${thread.messages.length}\n\n`;
+			markdown += '### Messages\n';
+
+			for (const msg of thread.messages) {
+				markdown += `#### Message ${msg.threadIndex}\n`;
+				markdown += `- **Sender**: ${msg.sender}\n`;
+				markdown += `- **Sent Date**: ${new Date(msg.sentDate).toLocaleString('en-US', { timeZone: 'America/Los_Angeles' })}\n`;
+				markdown += `- **Body**: ${String(msg.body || '').replace(/\n/g, ' ')}\n`;
+				markdown += `- **Sentiment**: ${msg.sentiment}\n\n`;
+
+				const s = String(msg.sentiment || '').toLowerCase();
+				if (s.includes('positive')) sentiments.positive++;
+				else if (s.includes('negative')) sentiments.negative++;
+				else if (s.includes('neutral')) sentiments.neutral++;
+			}
+		}
+
+		markdown += '## Overall Summary\n';
+		markdown += `- **Total Messages Processed**: ${Object.keys(this.results).length}\n`;
+		markdown += `- **Positive**: ${sentiments.positive}\n`;
+		markdown += `- **Negative**: ${sentiments.negative}\n`;
+		markdown += `- **Neutral**: ${sentiments.neutral}\n`;
+		return markdown;
+	}
+}
+
+module.exports = { MessageProcessor };
+
+

--- a/ollama-sentiment.js
+++ b/ollama-sentiment.js
@@ -49,9 +49,9 @@ Analyze the CURRENT message using the prior messages as context. Detect high-con
 Return ONLY compact JSON with keys: sentiment, conflict_level, deception_risk, flags, reason. Do not add extra text or explanations outside the JSON.
 
 Definitions:
-- sentiment: "positive" | "neutral" | "negative" | "mixed"
-- conflict_level: "low" | "medium" | "high"
-- deception_risk: "low" | "medium" | "high"
+- sentiment: "-1 to 1"
+- conflict_level: "0 - 10"
+- deception_risk: "0 - 10"
 - flags: zero or more of ["insult","threat","gaslighting" (denying reality to confuse),"darvo" (deny, attack, reverse victim/offender),"blame-shift","minimization","legal-threat","coercion","manipulation","profanity","boundary-violation","inconsistency" (mismatches with prior messages),"false-allegation"]
 - reason: one short sentence citing the behavior (quote or paraphrase)
 
@@ -60,7 +60,7 @@ Consider indicators: aggression, contempt, threats, legal intimidation, shifting
 Few-shot example:
 Prior: "I'll pick up the kids at 5 PM as agreed."
 Current: "You never show up on time, you're always late and ruining their lives."
-Output: {"sentiment":"negative","conflict_level":"high","deception_risk":"medium","flags":["blame-shift","exaggerated-absolutes"],"reason":"Message shifts blame with exaggerated claim of 'always late' despite prior agreement."}
+Output: {"sentiment":"-.9","conflict_level":"9","deception_risk":"5","flags":["blame-shift","exaggerated-absolutes"],"reason":"Message shifts blame with exaggerated claim of 'always late' despite prior agreement."}
 `;
 		try {
 			// Limit context to avoid overwhelming the model

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,21 @@
 {
   "name": "ofw-tools",
-  "version": "1.7.0",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ofw-tools",
-      "version": "1.7.0",
+      "version": "1.10.0",
       "license": "CC0-1.0",
       "dependencies": {
+        "fs-extra": "^11.2.0",
         "natural": "^6.8.0",
+        "ollama": "^0.5.8",
         "pdf-parse": "^1.1.1",
         "polarity": "^4.0.1",
-        "sentiment": "^5.0.2"
+        "sentiment": "^5.0.2",
+        "winston": "^3.14.2"
       },
       "devDependencies": {
         "jest": "^29.7.0"
@@ -564,6 +567,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
+      "integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
+      "license": "MIT",
+      "dependencies": {
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1048,6 +1071,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
@@ -1159,6 +1188,12 @@
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -1481,6 +1516,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/color": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1498,8 +1543,42 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "license": "MIT"
+    },
+    "node_modules/colorspace": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
+      "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^3.1.3",
+        "text-hex": "1.0.x"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -1641,6 +1720,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
+      "license": "MIT"
+    },
     "node_modules/error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -1752,6 +1837,12 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -1777,6 +1868,26 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "license": "MIT"
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+      "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/fs.realpath": {
@@ -1880,7 +1991,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-flag": {
@@ -1969,7 +2079,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/is-arrayish": {
@@ -2029,7 +2138,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2797,6 +2905,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -2806,6 +2926,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "license": "MIT"
     },
     "node_modules/leven": {
       "version": "3.1.0",
@@ -2835,6 +2961,23 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/logform": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/lru-cache": {
@@ -3002,6 +3145,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/ollama": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/ollama/-/ollama-0.5.17.tgz",
+      "integrity": "sha512-q5LmPtk6GLFouS+3aURIVl+qcAOPC4+Msmx7uBb3pd+fxI55WnGjmLZ0yijI/CYy79x0QPGx3BwC3u5zv9fBvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-fetch": "^3.6.20"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3010,6 +3162,15 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
       }
     },
     "node_modules/onetime": {
@@ -3282,6 +3443,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -3346,6 +3521,26 @@
         "node": ">=10"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safe-stable-stringify": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
@@ -3402,6 +3597,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+      "license": "MIT"
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -3447,6 +3657,15 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -3466,6 +3685,15 @@
       "integrity": "sha512-I6GPS/E0zyieHehMRPQcqkiBMJKGgLta+1hREixhoLPqEA0AlVFiC43dl8uPpmkkeRdDMzYRWFWk5/l9x7nmNg==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-length": {
@@ -3592,6 +3820,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "license": "MIT"
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -3610,6 +3844,15 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/type-detect": {
@@ -3647,6 +3890,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
@@ -3678,6 +3930,12 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
@@ -3703,6 +3961,12 @@
         "makeerror": "1.0.12"
       }
     },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+      "license": "MIT"
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3717,6 +3981,42 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/winston": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.17.0.tgz",
+      "integrity": "sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.7.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/wordnet-db": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ofw-tools",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "This repository contains a set of small, focused tools that help analyze communications, plan visitation schedules, and perform basic family-law-related calculations (Moore/Marsden, apportionment). These are optimized for quick, local use as you prepare materials for court.",
   "main": "index.js",
   "scripts": {
@@ -8,6 +8,7 @@
     "test": "jest",
     "prompts:validate": "node scripts/validate-prompts.js",
     "ofw:analyze": "node ofw.js",
+    "ofw:analyze-ollama": "node ofw.js --ollama",
     "ofw:clusters": "node message-volume.js",
     "visitation": "node visitation-cal.js",
     "nth-week": "node nth-week.js",
@@ -24,10 +25,13 @@
   "author": "",
   "license": "CC0-1.0",
   "dependencies": {
+    "fs-extra": "^11.2.0",
     "natural": "^6.8.0",
+    "ollama": "^0.5.8",
     "pdf-parse": "^1.1.1",
     "polarity": "^4.0.1",
-    "sentiment": "^5.0.2"
+    "sentiment": "^5.0.2",
+    "winston": "^3.14.2"
   },
   "devDependencies": {
     "jest": "^29.7.0"


### PR DESCRIPTION
## Summary

## [1.11.0] - 2025-08-15

PR: [#19](https://github.com/jozecuervo/ofw-tools/pull/19)

### Added
- Optional Ollama-based LLM sentiment post-processing for OFW analysis:
  - New flag `--ollama` on `ofw.js` to re-process the generated JSON with a local LLM
  - New module `ollama-sentiment.js` implementing context-aware sentiment with limited thread context (default 3 prior messages)
  - Outputs written alongside the original JSON in `./output/`:
    - `<report> - LLM processed.json` (adds `sentiment_ollama` per message)
    - `<report> - summary.md` (thread summaries with per-message sentiments and overall counts)
- NPM script: `ofw:analyze-ollama` → `node ofw.js --ollama`

### Changed
- CLI help updated to document `--ollama`
- CLI argument parsing made order-agnostic for input file (first non-flag token)

### Dependencies
- Added `ollama`, `fs-extra`, and `winston`

### Notes
- Requires a local Ollama server and model: `ollama pull llama3.1` and `ollama serve`
- CommonJS import uses the ESM default export: `const { default: ollama } = require('ollama')`

## Checklist (Repo Rules)

- [ ] package.json version bumped (SemVer)
- [ ] CHANGELOG.md updated with a new entry
- [ ] Changes are small and discrete (avoid large mixed commits)
- [ ] Tests updated/added as needed

## Notes

Link to relevant files (e.g., `output/`, `source_files/`) or artifacts if applicable.


